### PR TITLE
[QA382] Accept sorry-cypress option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,15 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gcloud-auth: ${{ secrets.GCLOUD_AUTH }}
-          bucket-name: "tests-data-eoiurg"
+          bucket-name: 'cg-live-tests'
           slack-token: ${{ secrets.SLACK_TOKEN }}
-          slack-channel: CBH555555
+          slack-channel: CBH5UR16Y
+          slack-mention: '@qa'
+          env: CG_AUTH_TOKEN=${{ secrets.CYPRESS_CG_AUTH_TOKEN }}
+          config: baseUrl=https://coingate.com
+          spec: ${{ steps.next-test.outputs.path }}
+          browser: chrome
+          sorry-cypress: true
+        env: 
+          CYPRESS_API_URL: "http://cg-cypress-sandbox-200193365.eu-central-1.elb.amazonaws.com:8080"
 ```

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,9 @@ inputs:
   working-directory:
     description: 'Working directory containing Cypress folder.'
     required: false
+  sorry-cypress:
+    description: 'Use sorry cypress? if true provide \n env: \n CYPRESS_API_URL: <url>'
+    required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,8 @@ const runTests = async (options: any = {}) => {
   const opts = {
     ...execCommandOptions,
   }
-  const cmd = ['cypress', 'run']
+
+  let cmd = []
 
   const envInput = core.getInput('env')
   if (envInput) {
@@ -43,7 +44,14 @@ const runTests = async (options: any = {}) => {
 
   const npxPath = await io.which('npx', true)
 
-  await exec.exec(quote(npxPath), cmd, opts)
+  let date = new Date();
+
+  const useSorryCypress = core.getInput('sorry-cypress')
+  if (useSorryCypress) {
+    await exec.exec(`${quote(npxPath)} cy2 run --parallel --record --key merged --ci-build-id "${date.toLocaleString()} | ${browserInput} | ${options.spec.slice(35,options.spec.length)}"`, cmd, opts)    
+  } else {
+    await exec.exec(`${quote(npxPath)} cypress run`, cmd, opts)    
+  }
 }
 
 const run = async () => {


### PR DESCRIPTION
```
      - name: Run Cypress Action
        uses: coingate/cypress-action@test/sorry-cypress
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          gcloud-auth: ${{ secrets.GCLOUD_AUTH }}
          bucket-name: 'cg-live-tests'
          slack-token: ${{ secrets.SLACK_TOKEN }}
          slack-channel: CBH5UR16Y
          slack-mention: '@qa'
          env: CG_AUTH_TOKEN=${{ secrets.CYPRESS_CG_AUTH_TOKEN }}
          config: baseUrl=https://coingate.com
          spec: ${{ steps.next-test.outputs.path }}
          browser: chrome
          sorry-cypress: true
        env: 
          CYPRESS_API_URL: "http://cg-cypress-sandbox-200193365.eu-central-1.elb.amazonaws.com:8080"
  ```

new option `sorry-cypress: true`  will allow us to toggle between casual cypress and sorry-cypress usage
With this we will need to provide `CYPRESS_API_URL` url in as environment param